### PR TITLE
不要修改原生库net.http的全局变量DefaultClient的内容

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -249,7 +249,7 @@ type service struct {
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *config.Configuration) *APIClient {
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = &http.Client{}
 	}
 
 	c := &APIClient{}


### PR DESCRIPTION
将http.DefaultClient直接赋值给cfg.HTTPClient,
后续对cfg.HTTPClient的修改直接影响的http.DefaultClient的内容，会给开发者带来很大麻烦。

Signed-off-by: windealli <windealli@tencent.com>